### PR TITLE
Update documentation with improved Uri method usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,36 +1,33 @@
-name: Publish to npm
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
-  publish:
-    name: Publish Package
+  build:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read  # necessary for checkout
-      packages: write # for publishing packages
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org/'
+          node-version: 20
+      - run: npm ci
+      - run: npm test
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build package
-        run: npm run build
-
-      - name: Publish to npm
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ yarn add request-uri
 
 #### Auto-Detects base url from request context
 
-- ✅ Node.js servers (e.g., Fastify, Express)
-- ✅ Browser apps (SPA, SSR)
-- ✅ Fetch/Request objects
-- ✅ Custom request objects (including from proxies or middleware)
+-   ✅ Node.js servers (e.g., Fastify, Express)
+-   ✅ Browser apps (SPA, SSR)
+-   ✅ Fetch/Request objects
+-   ✅ Custom request objects (including from proxies or middleware)
 
 Uri automatically resolves a base URL from:
 
-- **Browser environment** (`window.location.origin`)
-- **Fastify requests** (`FastifyRequest`)
-- **Fetch API `Request` objects**
-- **Plain JS objects** `{ protocol, host, port }`
-- **Raw string url**
-- **Fallback base url** (if everything else fails)
+-   **Browser environment** (`window.location.origin`)
+-   **Fastify requests** (`FastifyRequest`)
+-   **Fetch API `Request` objects**
+-   **Plain JS objects** `{ protocol, host, port }`
+-   **Raw string url**
+-   **Fallback base url** (if everything else fails)
 
 ```ts
 const uri = Uri.from("/path", request); // Automatically detects base from request object
@@ -46,26 +46,27 @@ Server-side set a global request object once:
 ```ts
 Uri.setRequest(serverReqeust);
 ```
+
 Build a new url with Uri
+
 ```ts
-const url = Uri.from('/v0/users').setPath('/v1/users').setQuery({ limit: 10, page: 2 });
+const url = Uri.from("/v0/users").setPath("/v1/users").setQuery({ limit: 10, page: 2 });
 
-url // output: URL
+url; // output: URL
 
-url.href //https://my-default.com/v1/users?limit=10&page=2
+url.href; //https://my-default.com/v1/users?limit=10&page=2
 ```
 
 ### Fluent Methods
 
 | **Method**              | **Support**      | **Description**               |
-|-------------------------|------------------|-------------------------------|
+| ----------------------- | ---------------- | ----------------------------- |
 | `setPath(path)`         | string\|string[] | Set or overwrite the pathname |
-| `setQuery(key, value)`  | (string, any)    | Add a single query param      |
-| `setQuery(obj)`         | Object           | Add multiple query params     |
+| `setQuery(key, value)`  | (string, any)    | Append a single query param   |
+| `setQuery(obj)`         | Object           | Append multiple query params  |
 | `setHost(host)`         | string           | Overwrite the host            |
 | `setPort(port)`         | string           | Overwrite the port            |
 | `setProtocol(protocol)` | string           | Overwrite the protocal        |
-
 
 ## Usage
 
@@ -88,19 +89,19 @@ Attach the request object globally using middleware:
 ```js
 // Middleware to attach the current request to Uri
 app.use((req, res, next) => {
-  Uri.setRequest(req);
-  next();
+	Uri.setRequest(req);
+	next();
 });
 ```
 
 Now you can generate full URLs using `Uri.from()`:
 
 ```ts
-app.get('/welcome', (req, res) => {
-  const url1 = Uri.from('new/path/auto-base');
-  const url2 = Uri.from('new/path/auto-base', req);
+app.get("/welcome", (req, res) => {
+	const url1 = Uri.from("new/path/auto-base");
+	const url2 = Uri.from("new/path/auto-base", req);
 
-  res.send(`url1: ${url1} <br> url2: ${url2}`);
+	res.send(`url1: ${url1} <br> url2: ${url2}`);
 });
 ```
 
@@ -111,20 +112,20 @@ app.get('/welcome', (req, res) => {
 Attach the request object using a Fastify lifecycle hook:
 
 ```js
-fastify.addHook('onRequest', (req, res, done) => {
-  Uri.setRequest(req);
-  done();
+fastify.addHook("onRequest", (req, res, done) => {
+	Uri.setRequest(req);
+	done();
 });
 ```
 
 Now you can use `Uri.from()` to build URLs:
 
 ```ts
-fastify.get('/welcome', (req, res) => {
-  const url1 = Uri.from('new/path/auto-base');
-  const url2 = Uri.from('new/path/auto-base', req);
+fastify.get("/welcome", (req, res) => {
+	const url1 = Uri.from("new/path/auto-base");
+	const url2 = Uri.from("new/path/auto-base", req);
 
-  res.send(`url1: ${url1} <br> url2: ${url2}`);
+	res.send(`url1: ${url1} <br> url2: ${url2}`);
 });
 ```
 
@@ -133,12 +134,14 @@ fastify.get('/welcome', (req, res) => {
 #### 🌐 Custom Request Capture with Fetch API
 
 **Set globally:**
+
 ```ts
 const request = new Request("https://api.example.com/original");
 Uri.setRequest(request);
 ```
 
 **Or pass individually:**
+
 ```ts
 const request = new Request("https://api.example.com/original");
 const uri = Uri.from("/override", request);
@@ -150,19 +153,21 @@ console.log(uri.href); // "https://api.example.com/override"
 #### 🛠️ Custom Raw Object for Request Simulation
 
 **Set globally:**
+
 ```ts
 Uri.setRequest({ protocol: "http", host: "localhost", port: 3000 });
 
 // Now use Uri.from
-Uri.from('/hello/world').href; // "http://localhost:3000/hello/world"
+Uri.from("/hello/world").href; // "http://localhost:3000/hello/world"
 ```
 
 **Use directly with a custom object:**
+
 ```ts
 const baseRequest = {
-  protocol: "http",
-  host: "localhost",
-  port: 3000,
+	protocol: "http",
+	host: "localhost",
+	port: 3000,
 };
 
 const uri = Uri.from("/local", baseRequest);
@@ -174,51 +179,54 @@ console.log(uri.href); // "http://localhost:3000/local"
 #### ✏️ Uri Modification Methods
 
 **Update the pathname:**
+
 ```ts
-Uri.from('/welcome').setPath('aboutus');
+Uri.from("/welcome").setPath("aboutus");
 // "http://localhost:3000/aboutus"
 ```
 
 **Add query parameters:**
+
 ```ts
 // Single query param
-Uri.from('/aboutus').setQuery('message', 'good');
+Uri.from("/aboutus").setQuery("message", "good");
 // "http://localhost:3000/aboutus?message=good"
 
 // Multiple query params
-Uri.from('/aboutus').setQuery({ message: 'good', count: '3' });
+Uri.from("/aboutus").setQuery({ message: "good", count: "3" });
 // "http://localhost:3000/aboutus?message=good&count=3"
 ```
 
 **Overwrite host:**
+
 ```ts
-Uri.from('/aboutus').setHost('example.com');
+Uri.from("/aboutus").setHost("example.com");
 // "http://example.com:3000/aboutus"
 ```
 
 **Overwrite port:**
+
 ```ts
-Uri.from('/aboutus').setPort(6000);
+Uri.from("/aboutus").setPort(6000);
 // "http://localhost:6000/aboutus"
 ```
 
 **Overwrite protocol:**
+
 ```ts
-Uri.from('/aboutus').setProtocol('ws');
+Uri.from("/aboutus").setProtocol("ws");
 // "ws://localhost:3000/aboutus"
 ```
-
-
 
 ## 🧪 Testing Strategy
 
 This package is **fully unit tested** and covers:
 
-- All base resolution types
-- All method chaining behaviors
-- Edge cases like missing hosts or protocol
-- Fallback behavior
-- Error handling when base URL is invalid
+-   All base resolution types
+-   All method chaining behaviors
+-   Edge cases like missing hosts or protocol
+-   Fallback behavior
+-   Error handling when base URL is invalid
 
 Run tests with:
 
@@ -243,18 +251,16 @@ Uri.request("/will-fail"); // ❌ throws Invalid URL
 
 If you’ve ever had to:
 
-- Safely build URLs in both Node and the browser
-- Parse requests from Fastify, Express, or Fetch
-- Avoid brittle string concatenation
-- Reuse base URLs with confidence
+-   Safely build URLs in both Node and the browser
+-   Parse requests from Fastify, Express, or Fetch
+-   Avoid brittle string concatenation
+-   Reuse base URLs with confidence
 
 ...this tiny utility saves time and avoids bugs by abstracting away the complexities of request context detection and clean URL building.
-
 
 ## Contributing
 
 Contributions are welcome! Feel free to open an issue or submit a pull request.
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add request-uri
 
 ## 🔧 Available features
 
-### ✅ Auto-Detects base url from request context
+#### Auto-Detects base url from request context
 
 Uri automatically resolves a base URL from:
 
@@ -24,25 +24,22 @@ Uri automatically resolves a base URL from:
 - **Fetch API `Request` objects**
 - **Plain JS objects** `{ protocol, host, port }`
 - **Raw string URLs**
-- **Fallback base URL** (if everything else fails)
+- **Fallback request or base URL** (when base resolve fails)
 
 ```ts
 const uri = Uri.from("/path", request); // Automatically detects base from request object
-//or 
-const uri = Uri.request("/path", request);
 ```
 
 Set a static fallback for cases when base cannot be resolved:
 
 ```ts
-Uri.fallbackBase = "https://my-default.com";
+Uri.fallback = "https://my-default.com";
 ```
 
 Or set a global request object once:
 
 ```ts
 Uri.setRequest(serverReqeust);
-const uri = Uri.from("/auto-detects-base");
 ```
 
 
@@ -72,20 +69,17 @@ Produces:
 https://api.example.com:8080/v1/users?limit=10&page=2
 ```
 
----
-
 ### ✍️ Fluent Methods
 
-| Method            | Description                                |
-|-------------------|--------------------------------------------|
-| `setPath(path)`   | Set or overwrite the pathname (string or array) |
-| `setQuery(key, value)` | Append a single query param |
-| `setQuery(obj)`   | Append multiple query params |
-| `setHost(host)`   | Overwrite the host                         |
-| `setPort(port)`   | Overwrite the port                         |
-| `setProtocol(protocol)` | Change the protocol (e.g., `https:`)     |
+| **Method**              | **Support**      | **Description**               |
+|-------------------------|------------------|-------------------------------|
+| `setPath(path)`         | string\|string[] | Set or overwrite the pathname |
+| `setQuery(key, value)`  | (string, any)    | Append a single query param   |
+| `setQuery(obj)`         | Object           | Append multiple query params  |
+| `setHost(host)`         | string           | Overwrite the host            |
+| `setPort(port)`         | string           | Overwrite the port            |
+| `setProtocol(protocol)` | string           | Overwrite the protocal        |
 
----
 
 ## 🔍 Usage Examples
 
@@ -103,6 +97,27 @@ console.log(uri.href); // e.g., "https://example.com/dashboard"
 fastify.get("/example", (req, reply) => {
   const uri = Uri.request("/users", req);
   console.log(uri.href); // Uses req.protocol and req.headers.host
+});
+```
+
+### Node Express request capture
+
+Node express js request capture with middleware 
+```js
+app.use(function(req, res, next){
+
+  Uri.setRequest(req);
+  next();
+  
+});
+```
+Node express js request capture inside of handler 
+```js
+app.get('/',function(req, res){
+
+  Uri.setRequest(req);
+
+  res.send('Hello');
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-uri",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Universal, environment-aware URL builder for browser, Node contexts.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export default class Uri extends UriHelper {
 	/**
 	 * Creates a new Uri instance from a path and optional request.
 	 */
-	static get(path: string, request?: UriRequest): Uri {
+	static make(path: string, request?: UriRequest): Uri {
 		return new this(path, this.getBase(request));
 	}
 
@@ -189,11 +189,11 @@ export default class Uri extends UriHelper {
 	 * Public interface to create a Uri instance.
 	 */
 	static from(path: string, request?: UriRequest): Uri {
-		return this.get(path, request);
+		return this.make(path, request);
 	}
 
 	/** Alise for Uri.get */
-	static request = this.get;
+	static request = this.make;
 }
 
 readonly(Uri, ["from", "get", "getBase", "getRequest", "setRequest", "request"]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,47 @@
 import type { FastifyRequest } from "fastify";
 
+/**
+ * Checks if a value is a plain object (i.e., not an array, function, null, etc.).
+ *
+ * @returns True if value is a plain object (optionally with keys), false otherwise.
+ */
+export function isObject(value: unknown, strict = false): value is Record<string, unknown> {
+	const isObjectLike = typeof value === "object" && value !== null && !Array.isArray(value);
+
+	if (!isObjectLike) return false;
+
+	return strict ? Object.keys(value as object).length > 0 : true;
+}
+
+/**
+ * Makes properties of an object read-only.
+ *
+ * @param o The object on which to define or modify properties.
+ * @param p A single property key or an array of property keys to make read-only.
+ * @returns The object with the specified properties made read-only.
+ * @throws {TypeError} If `o` is not an object or `null`.
+ */
+export function readonly<T extends object>(o: T, p: PropertyKey | PropertyKey[]): T {
+	//
+	const keysToProcess = Array.isArray(p) ? p : [p];
+
+	for (const key of keysToProcess) {
+		// Only apply if the property actually exists on the object
+		// This prevents creating new, non-writable properties accidentally
+		if (Object.prototype.hasOwnProperty.call(o, key)) {
+			//
+			Object.defineProperty(o, key, {
+				writable: false,
+				configurable: false,
+				enumerable: true,
+				value: o[key as keyof T], // Type assertion for safety
+			});
+		}
+	}
+
+	return o; // Return the modified object for chaining or direct use
+}
+
 export type CustomRequest = {
 	host?: string;
 	protocol?: string;
@@ -9,63 +51,22 @@ export type CustomRequest = {
 
 export type UriRequest = FastifyRequest | Request | CustomRequest | string;
 
-export default class Uri extends URL {
+//Uri helper class
+export class UriHelper extends URL {
+	//
+
+	/**
+	 * @deprecated Use `Uri.fallback` instead. This will be removed in future versions.
+	 */
+	static get fallbackBase(): string | undefined {
+		return this.fallback;
+	}
+	static set fallbackBase(value: string | undefined) {
+		this.fallback = value;
+	}
+
 	/** Used as the fallback base URL when none is provided. */
-	static fallbackBase?: string;
-
-	/** Request object for internal use. */
-	static #request?: UriRequest;
-
-	/**
-	 * Sets the default request object used to resolve the URI base.
-	 *
-	 * @param {UriRequest} request The request object.
-	 */
-	static setRequest(request: UriRequest) {
-		this.#request = request;
-	}
-
-	/**
-	 * Attempts to resolve a base URL (origin) from various types of request.
-	 * This is useful in both server-side and client-side environments to dynamically construct
-	 *
-	 * Supports:
-	 * - Browser environments (uses `window.location.origin`)
-	 * - String URLs
-	 * - Fetch API Request objects
-	 * - FastifyRequest and similar server request objects
-	 * - Plain objects with `headers`, `protocol`, `host`, and `port` fields
-	 *
-	 * Falls back to a static `fallbackBase` if resolution fails.
-	 */
-	static #resolveBaseFromRequest(request?: UriRequest): string | undefined {
-		// Use the provided request or the previously set static request
-		request = request || this.#request;
-
-		// 1. Browser environment: use window.location.origin if available
-		if (typeof window !== "undefined" && window?.location?.origin) {
-			return window.location.href || window.location.origin;
-		}
-
-		// 2. If the request is a string (e.g., a URL), try parsing it
-		if (typeof request === "string") return request;
-
-		// 3. If it's a Fetch API Request object, return the full URL
-		if (request instanceof Request) return request.url;
-
-		// 4. Fastify request construct base
-		if (request && request.headers?.host && request.protocol) {
-			return `${request.protocol}://${request.headers.host}`;
-		}
-
-		// 6. Generic object with protocol, host, and port
-		if (request && typeof request === "object" && request.protocol && request.host && request.port) {
-			return `${request.protocol}://${request.host}:${request.port}`;
-		}
-
-		// 7. Fallback base if no conditions are met
-		return this.fallbackBase;
-	}
+	static fallback?: string;
 
 	/**
 	 * Appends query parameters to the URI.
@@ -121,42 +122,78 @@ export default class Uri extends URL {
 		this.pathname = Array.isArray(path) ? path.join("/") : path;
 		return this;
 	}
+}
+
+export default class Uri extends UriHelper {
+	//
+
+	/** Request object for internal use. */
+	static #_request?: UriRequest;
+
+	/**
+	 * Sets the default request object used to resolve the URI base.
+	 *
+	 * @param {UriRequest} request The request object.
+	 */
+	static setRequest(request: UriRequest) {
+		this.#_request = request;
+	}
+
+	/**
+	 * Get the default request object.
+	 */
+	protected static getRequest() {
+		return this.#_request;
+	}
+
+	/**
+	 * Get base url from request or fallback.
+	 */
+	static getBase(request?: UriRequest): string | undefined {
+		// Use the provided request or the previously set static request
+		request = request || this.getRequest();
+
+		// 1. Browser environment: use window.location.origin if available
+		if (typeof window !== "undefined" && window?.location?.origin) {
+			return window.location.href || window.location.origin;
+		}
+
+		// 2. If the request is a string (e.g., a URL), try parsing it
+		if (typeof request === "string") return request;
+
+		// 3. If it's a Fetch API Request object, return the full URL
+		if (request instanceof Request) return request.url;
+
+		// 4. Fastify request construct base
+		if (request && request.headers?.host && request.protocol) {
+			return `${request.protocol}://${request.headers.host}`;
+		}
+
+		// 6. Generic object with protocol, host, and port
+		if (request && typeof request === "object" && request.protocol && request.host && request.port) {
+			return `${request.protocol}://${request.host}:${request.port}`;
+		}
+
+		// 7. Fallback base if no conditions are met
+		return this.fallbackBase;
+	}
 
 	/**
 	 * Creates a new Uri instance from a path and optional request.
-	 * @param {string} path The relative or absolute path.
-	 * @param {UriRequest} [request] Optional request object.
-	 * @returns {Uri} New Uri instance.
 	 */
-	private static _request(path: string, request?: UriRequest): Uri {
-		const base = this.#resolveBaseFromRequest(request);
-		return new this(path, base);
+	static get(path: string, request?: UriRequest): Uri {
+		return new this(path, this.getBase(request));
 	}
 
 	/**
 	 * Public interface to create a Uri instance.
-	 * @param {string} path Path string.
-	 * @param {UriRequest} [request] Optional request object.
-	 * @returns {Uri} New Uri instance.
 	 */
-	static readonly request = Uri._request;
+	static from(path: string, request?: UriRequest): Uri {
+		return this.get(path, request);
+	}
 
-	/** Alias for `request`. */
-	static readonly from = Uri._request;
+	/** Alise for Uri.get */
+	static request = this.get;
 }
 
-// Make `request` method immutable and enumerable on Uri.
-Object.defineProperty(Uri, "request", {
-	writable: false,
-	configurable: false,
-	enumerable: true,
-	value: Uri.request,
-});
-
-// Make `from` alias immutable and enumerable on Uri.
-Object.defineProperty(Uri, "from", {
-	writable: false,
-	configurable: false,
-	enumerable: true,
-	value: Uri.from,
-});
+readonly(Uri, ["from", "get", "getBase", "getRequest", "setRequest", "request"]);


### PR DESCRIPTION
This PR updates the README documentation to improve clarity and usage examples of the `Uri` methods.

Changes include:
- Organized sections for different environments: Browser, Express.js, Fastify, and custom requests
- Clearer explanations for `Uri.setRequest`, `Uri.from`, and other chainable methods like `.setPath`, `.setQuery`, etc.
- Corrected grammar and formatting for better readability
- Added a simple contributing section

These improvements aim to make the documentation more helpful and beginner-friendly.

Let me know if any further adjustments are needed.
